### PR TITLE
修改封面的文件名

### DIFF
--- a/bilinovel2epub.py
+++ b/bilinovel2epub.py
@@ -196,6 +196,9 @@ def 标准化JSON(s:str)->dict:
     return obj
 
 def clean_file_name(filename:str):
+    if ".jpg?" in filename:
+        parts = filename.split(".jpg?")
+        filename = parts[0] + ".jpg"
     invalid_chars='[\\\:*?"<>|]'
     replace_char='-'
     return re.sub(invalid_chars,replace_char,filename)


### PR DESCRIPTION
部分epub阅读器（如win平台下的starrea）无法处理形如`"image-2-2547-2547s.jpg-214323.jpg-214323"`的图像文件，会导致生成的epub无法打开，sigil 报错如下：

`OPF对文件 "image-2-2547-2547s.jpg-214323.jpg-214323" 使用了无法识别的媒体类型 "application/octet-stream" - "" 临时媒体类型已分配。你应该编辑你的OPF文件来解决这个问题。`

仅发现了封面图像有这个问题，其他文件正常。